### PR TITLE
Fix typo in mod/advanced_rocketry

### DIFF
--- a/mod/advanced_rocketry.txt
+++ b/mod/advanced_rocketry.txt
@@ -1,2 +1,2 @@
 name: Advanced Rocketry
-alt: ggalacticraft
+alt: galacticraft


### PR DESCRIPTION
"ggalacticraft" instead of "galacticraft"